### PR TITLE
Add AI integration and image generation to marketing agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Sitio listo para publicar sin build. Incluye:
 - React vía CDN (esm.run)
 - Tailwind vía CDN
 - Generación de texto por plantillas (funciona sin API)
-- Opción de usar OpenAI si pegas tu API key (cliente, solo demo)
-- Imágenes con Pollinations (sin clave)
+- Campo para pegar tu API key de OpenAI y generar con `gpt-4o-mini`
+- Imágenes generadas con Pollinations (sin clave)
 - Exportables: CSV, ICS, PPTX y DOCX via ESM (pptxgenjs/docx)
 
 ## Cómo publicarlo en GitHub Pages
@@ -20,4 +20,4 @@ Sitio listo para publicar sin build. Incluye:
 7. Abre el link: verás la app funcionando.
 
 > Sin API key ya puedes generar contenido (modo plantillas) y usar imágenes (Pollinations).
-> Si pegas una API key de OpenAI, se intentará generar con `gpt-4o-mini` desde el navegador.
+> Si pegas una API key de OpenAI en el campo superior, se intentará generar con `gpt-4o-mini` desde el navegador.


### PR DESCRIPTION
## Summary
- integrate optional OpenAI generation via new `generateAIResponse` helper
- expose API key input and fallback to template-based content
- display Pollinations image suggestions and document setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b315762a8083249302bbc95a4cbed8