### PR TITLE
Add Excel content calendar generator

### DIFF
--- a/app.js
+++ b/app.js
@@ -325,6 +325,110 @@ function ToolModal({ tool, apiKey, onClose }) {
   );
 }
 
+function ExcelGenerator() {
+  const [specialty, setSpecialty] = useState("");
+  const [contentType, setContentType] = useState("");
+  const [period, setPeriod] = useState("");
+  const [frequency, setFrequency] = useState("");
+  const [context, setContext] = useState("");
+
+  const handleGenerate = () => {
+    if (!specialty || !contentType || !period || !frequency) return;
+    const start = new Date();
+    const end = new Date(start);
+    if (period === "1 mes") end.setMonth(start.getMonth() + 1);
+    else if (period === "3 meses") end.setMonth(start.getMonth() + 3);
+    else if (period === "6 meses") end.setMonth(start.getMonth() + 6);
+
+    const step =
+      frequency === "Semanal" ? 7 : frequency === "Quincenal" ? 14 : 30;
+    const rows = [];
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + step)) {
+      rows.push({
+        Fecha: d.toISOString().split("T")[0],
+        Especialidad: specialty,
+        "Tipo de Contenido": contentType,
+        Contexto: context
+      });
+    }
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.json_to_sheet(rows);
+    XLSX.utils.book_append_sheet(wb, ws, "Calendario");
+    XLSX.writeFile(wb, "calendario_contenido.xlsx");
+  };
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-6 space-y-4">
+      <h3
+        className="text-xl font-semibold text-center"
+        style={{ color: BRAND.navy }}
+      >
+        Configuración del Excel
+      </h3>
+      <p className="text-gray-600 text-center">
+        Define los parámetros para generar tu calendario de contenido
+      </p>
+      <div className="space-y-3">
+        <select
+          className="w-full border rounded-xl p-2"
+          value={specialty}
+          onChange={e => setSpecialty(e.target.value)}
+        >
+          <option value="">Selecciona una especialidad</option>
+          <option>Corporativo</option>
+          <option>Laboral</option>
+          <option>Tributario</option>
+          <option>Tech & Startups</option>
+        </select>
+        <select
+          className="w-full border rounded-xl p-2"
+          value={contentType}
+          onChange={e => setContentType(e.target.value)}
+        >
+          <option value="">Selecciona el tipo</option>
+          <option>Artículo</option>
+          <option>Video</option>
+          <option>Post en Redes</option>
+          <option>Infografía</option>
+        </select>
+        <select
+          className="w-full border rounded-xl p-2"
+          value={period}
+          onChange={e => setPeriod(e.target.value)}
+        >
+          <option value="">Selecciona periodo</option>
+          <option>1 mes</option>
+          <option>3 meses</option>
+          <option>6 meses</option>
+        </select>
+        <select
+          className="w-full border rounded-xl p-2"
+          value={frequency}
+          onChange={e => setFrequency(e.target.value)}
+        >
+          <option value="">¿Con qué frecuencia?</option>
+          <option>Semanal</option>
+          <option>Quincenal</option>
+          <option>Mensual</option>
+        </select>
+        <textarea
+          className="w-full border rounded-xl p-2"
+          placeholder="Contexto adicional"
+          value={context}
+          onChange={e => setContext(e.target.value)}
+        />
+        <button
+          onClick={handleGenerate}
+          className="w-full px-4 py-2 rounded-xl text-white"
+          style={{ background: BRAND.primary }}
+        >
+          Generar Calendario de Contenido
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function App() {
   const [active, setActive] = useState(null);
   const [apiKey, setApiKey] = useState(
@@ -365,6 +469,9 @@ function App() {
           />
         </div>
       </header>
+      <section className="max-w-3xl mx-auto px-4 mb-8">
+        <ExcelGenerator />
+      </section>
 
       <section className="max-w-5xl mx-auto px-4 space-y-6">
         <div className="text-center">

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <style>
     :root{ --lh-bg:#F2F2F7; --lh-primary:#60189C; --lh-teal:#00B989; --lh-navy:#172755; --lh-cyan:#41E1F2; }
     body{ font-family:'Open Sans',system-ui,Segoe UI,Roboto,Arial,sans-serif; background:var(--lh-bg); }


### PR DESCRIPTION
## Summary
- integrate SheetJS and add ExcelGenerator component with configurable specialty, content type, period, frequency and context
- render form in landing page for marketing agents to export content calendar as XLSX

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b318a9c22c8324a71545edfbadf802