### PR TITLE
fix: load app script without module type

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,7 @@
   <script
     type="text/babel"
     src="app.js"
-    data-presets="env,react"
-    data-type="module">
+    data-presets="env,react">
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load React app script without `module` type to run with Babel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32550700c832482640fc6d66fe062