### PR TITLE
Fix missing closing div in ExcelGenerator

### DIFF
--- a/app.js
+++ b/app.js
@@ -529,6 +529,7 @@ function ExcelGenerator() {
         </button>
       </div>
     </div>
+  </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- fix syntax error by adding missing closing `<div>` in `ExcelGenerator`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b333b9323c8324adb285486ab1c6d5